### PR TITLE
Implement some light refactorings.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,11 +3,10 @@ name = "warehouse"
 version = "0.1.0"
 dependencies = [
  "env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "iron 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iron 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "router 0.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "persistent 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "router 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -22,10 +21,10 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -115,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "iron"
-version = "0.1.21"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -177,7 +176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -236,6 +235,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "persistent"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "iron 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,8 +279,8 @@ name = "regex"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -288,10 +296,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "router"
-version = "0.0.14"
+version = "0.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "iron 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iron 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "route-recognizer 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,9 @@ version = "0.1.0"
 authors = ["Steve Klabnik <steve@steveklabnik.com>"]
 
 [dependencies]
-iron = "0.1.21"
-router = "0.0.14"
-lazy_static = "0.1.14"
+iron = "0.2"
+router = "0.0.15"
 serde_json = "0.5.1"
-hyper = "0.6.11"
 log = "0.3.2"
 env_logger = "0.3.1"
+persistent = "0.0.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,28 +4,23 @@ extern crate iron;
 #[macro_use]
 extern crate router;
 extern crate serde_json;
-#[macro_use]
-extern crate lazy_static;
-extern crate hyper;
 
 #[macro_use]
 extern crate log;
 extern crate env_logger;
 
-use router::Router;
+extern crate persistent;
+
 use iron::prelude::*;
 use iron::status;
-use hyper::header::AccessControlAllowOrigin;
+use iron::headers::AccessControlAllowOrigin;
+use persistent::Read;
 
 mod totally_not_a_database;
 mod krate;
 mod version;
 
 use totally_not_a_database::TotallyNotADatabase;
-
-lazy_static! {
-    static ref STORE: TotallyNotADatabase = { TotallyNotADatabase::new() };
-}
 
 fn main() {
     env_logger::init().unwrap();
@@ -35,11 +30,19 @@ fn main() {
                          get "/crates" => crates);
 
     info!("Initializing data...");
-    // let's not be lazy! (Load the data at startup, rather than on the first request
-    &STORE.0; 
+    let data = TotallyNotADatabase::new();
     info!("Data loaded");
 
     let mut chain = Chain::new(router);
+
+    chain.link(Read::<TotallyNotADatabase>::both(data));
+
+    chain.link_before(|req: &mut Request| {
+        // Basic logging of requests.
+        info!("REQUEST: {}", req.url.path.join("/"));
+        Ok(())
+    });
+
     chain.link_after(|_: &mut Request, mut res: Response| {
         // lol
         res.headers.set(AccessControlAllowOrigin::Any);
@@ -52,15 +55,11 @@ fn main() {
 }
 
 fn index(_: &mut Request) -> IronResult<Response> {
-    info!("REQUEST: /");
-    let index = String::from("{\"crates\": \"/crates\"}");
-
-    Ok(Response::with((status::Ok, index)))
+    Ok(Response::with((status::Ok, r#"{"crates": "crates"}"#)))
 }
 
-fn crates(_: &mut Request) -> IronResult<Response> {
-    info!("REQUEST: /crates");
-    let data = &STORE.0;
+fn crates(req: &mut Request) -> IronResult<Response> {
+    let data = &req.get_ref::<Read<TotallyNotADatabase>>().unwrap().0;
 
     let mut json = String::from("{\"data\":[");
 

--- a/src/totally_not_a_database.rs
+++ b/src/totally_not_a_database.rs
@@ -8,7 +8,11 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufReader;
 
+use iron::typemap::Key;
+
 pub struct TotallyNotADatabase(pub BTreeMap<String, Crate>);
+
+impl Key for TotallyNotADatabase { type Value = TotallyNotADatabase; }
 
 fn bad_entry(entry: &fs::DirEntry) -> bool {
     let bad_paths = ["crates.io-index/config.json", "crates.io-index/.git"];
@@ -47,7 +51,7 @@ impl TotallyNotADatabase {
                 }
             }
         }
-        
+
         TotallyNotADatabase(db)
     }
 }


### PR DESCRIPTION
Use persistent instead of lazy_static to avoid global variables.

Factor out logging into a super simple BeforeMiddleware.

Use iron's headers reexports instead of depending on hyper directly.

Update to use iron 0.2.

Make some other small changes.
